### PR TITLE
fix: UnhandledPromiseRejectionWarning

### DIFF
--- a/src/write-api.js
+++ b/src/write-api.js
@@ -490,8 +490,17 @@ function WriteApi(Network, network, config, Transaction) {
     const txObject = Transaction.fromObject(rawTx)
     // console.log('txObject', txObject)
 
-    const buf = Fcbuffer.toBuffer(Transaction, txObject)
-    const tr = Transaction.toObject(txObject)
+    // fix: UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]
+    // if unhandle promise reject, outside can not catch this error.
+    let buf;
+    let tr;
+    try {
+      buf = Fcbuffer.toBuffer(Transaction, txObject);
+      tr = Transaction.toObject(txObject);
+    } catch (e) {
+      callback(error);
+      return;
+    }
 
     const transactionId  = createHash('sha256').update(buf).digest().toString('hex')
 


### PR DESCRIPTION
When passing invalid arg type to contract method, `UnhandledPromiseRejectionWarning,` will come out, and outside can not  catch this error, so process will crash like below:

```
(node:66032) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be one of type string, TypedArray, or DataView. Received type undefined
    at Hash.update (internal/crypto/hash.js:58:11)
    at transaction$ (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/bosjs/lib/write-api.js:850:50)
    at tryCatch (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:114:21)
    at tryCatch (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:62:40)
    at invoke (/Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:152:20)
    at /Users/sunyuangao/Desktop/2.Developing/cold-wallet/node_modules/regenerator-runtime/runtime.js:162:13
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:66032) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:66032) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```